### PR TITLE
Set auto order packages for composer require

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,8 @@
         }
     },
     "config": {
-      "bin-dir": "bin/"
+      "bin-dir": "bin/",
+      "sort-packages": true
     },
     "scripts": {
         "post-composer-scripts": [


### PR DESCRIPTION
I suggest you to use the option `sort-packages` to have all packages order by name on composer require.